### PR TITLE
Implement champion tags

### DIFF
--- a/RaidExtractor.Core/AccountDumpClient.cs
+++ b/RaidExtractor.Core/AccountDumpClient.cs
@@ -391,6 +391,9 @@ namespace RaidExtractor.Core
         [Newtonsoft.Json.JsonProperty("inStorage", Required = Newtonsoft.Json.Required.Always)]
         public bool InStorage { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("marker", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Marker { get; set; }
+
         [Newtonsoft.Json.JsonProperty("artifacts", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<int> Artifacts { get; set; }
 

--- a/RaidExtractor.Core/Extractor.cs
+++ b/RaidExtractor.Core/Extractor.cs
@@ -223,6 +223,7 @@ namespace RaidExtractor.Core
                         FullExperience = heroStruct.FullExperience,
                         Locked = heroStruct.Locked,
                         InStorage = heroStruct.InStorage,
+                        Marker = heroStruct.Marker.ToString(),
                         Masteries = new List<int>(),
                     };
 

--- a/RaidExtractor.Core/Native/HeroMarker.cs
+++ b/RaidExtractor.Core/Native/HeroMarker.cs
@@ -1,0 +1,15 @@
+﻿namespace RaidExtractor.Core.Native
+{
+    public enum HeroMarker : int
+    {
+        None = 0,
+        Favorite = 1,
+        First = 100,
+        Second = 101,
+        Third = 102,
+        Attack = 200,
+        Defence = 201,
+        Support = 202,
+        Speed = 203
+    }
+}

--- a/RaidExtractor.Core/Native/HeroStruct.cs
+++ b/RaidExtractor.Core/Native/HeroStruct.cs
@@ -27,7 +27,9 @@ namespace RaidExtractor.Core.Native
         [FieldOffset(0x38)]
         public IntPtr RecentBattleTimePtr; 
         [FieldOffset(0x40)]
-        public long RecentBattleTime; 
+        public long RecentBattleTime;
+        [FieldOffset(0x48)]
+        public HeroMarker Marker;
         [FieldOffset(0x50)]
         public IntPtr Skills; 
         [FieldOffset(0x58)]


### PR DESCRIPTION
Implements the champion tags that were introducted in Raid v3.40 to be extracted into the json file. Values are based on the internal enum (first, second, third instead of First Build, Second Build, Third Build).