### PR TITLE
Arena and Great Hall extraction support

### DIFF
--- a/Python Utilities/address_extractor.py
+++ b/Python Utilities/address_extractor.py
@@ -17,7 +17,10 @@ findclasslist = {
     'public abstract class HeroesWrapperReadOnly ': [{
         'protected readonly UpdatableArtifactData ArtifactData;': '        public static int HeroesWrapperArtifactData = {}; // HeroesWrapperReadOnly.ArtifactData\n',
         'protected readonly UpdatableHeroData HeroData;': '        public static int HeroesWrapperHeroData = {}; // HeroesWrapperReadOnly.HeroData\n',
-    }],    
+    }],
+    'public abstract class ArenaWrapperReadOnly ': [{
+        'protected Nullable<ArenaLeagueId> LeagueId;': '        public static int ArenaWrapperLeagueId = {}; // ArenaWrapperReadOnly.LeagueId\n',
+    }],
     'public class UserArtifactData ': [{
         'public List<Artifact> Artifacts;': '        public static int UserArtifactDataArtifacts = {}; // UserArtifactData.Artifactsa\n',
         'public Dictionary<int, HeroArtifactData> ArtifactDataByHeroId;': '        public static int UserArtifactArtifactDataByHeroId = {}; // UserArtifactData.ArtifactDataByHeroId\n',

--- a/Python Utilities/address_extractor.py
+++ b/Python Utilities/address_extractor.py
@@ -21,12 +21,18 @@ findclasslist = {
     'public abstract class ArenaWrapperReadOnly ': [{
         'protected Nullable<ArenaLeagueId> LeagueId;': '        public static int ArenaWrapperLeagueId = {}; // ArenaWrapperReadOnly.LeagueId\n',
     }],
+    'public abstract class CapitolWrapperReadOnly ': [{
+        'protected readonly UpdatableVillageData VillageData;': '        public static int CapitolWrapperVillageData = {}; // CapitolWrapperReadOnly.VillageData\n',
+    }],
     'public class UserArtifactData ': [{
         'public List<Artifact> Artifacts;': '        public static int UserArtifactDataArtifacts = {}; // UserArtifactData.Artifactsa\n',
         'public Dictionary<int, HeroArtifactData> ArtifactDataByHeroId;': '        public static int UserArtifactArtifactDataByHeroId = {}; // UserArtifactData.ArtifactDataByHeroId\n',
     }],
     'public class UserHeroData ': [{
         'public Dictionary<int, Hero> HeroById;': '        public static int UserHeroDataHeroById = {}; // UserHeroData.HeroById\n',
+    }],
+    'public class UserVillageData ': [{
+        'public Dictionary<Element, Dictionary<StatKindId, int>> CapitolBonusLevelByStatByElement;': '        public static int UserVillageDataCapitolBonusLevelByStatByElement = {}; // UserVillageData.UserVillageDataCapitolBonusLevelByStatByElement\n',
     }],
 }
 
@@ -90,7 +96,9 @@ def dump_class(vernum, metadata_path):
     if classesfound != len(findclasslist):
         print(str.format('*** ERROR *** Expected {} classes, found {} classes.', len(findclasslist), classesfound))
 
+    outfile.write('        public static int DictionaryEntries = 0x18; // Dictionary.Entries\n')
     outfile.write('        public static int DictionaryCount = 0x20; // Dictionary.Count\n')
+    outfile.write('        public static int ListCount = 0x18; // List.Count\n')
 
     outfile.write('    }\n')
     outfile.write('}\n')

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RaidExtractor
-A tool made to extract information from the windows version of "Raid: Shadow Legends". Currently it supports v0.230 (as seen in Plarium Play launcher) and currently only extracts artifacts and current champions.
+A tool made to extract information from the windows version of "Raid: Shadow Legends". Currently it supports v0.237 (as seen in Plarium Play launcher) and currently only extracts artifacts and current champions.
 
 This application has 2 Modes:
 * A Windows GUI application. The functionality is slim, but it works!
@@ -13,7 +13,8 @@ This application has 2 Modes:
 * .NET Framework 4.8
 
 ## Future versions
-* Add Great Hall and Arena data
+* Extract last known hero compositions
+* Account stats
 
 ## Projects Using Extracted Data!
 Several other projects already exist that like to use the data this project extracts!

--- a/RaidExtractor.Core/AccountDumpClient.cs
+++ b/RaidExtractor.Core/AccountDumpClient.cs
@@ -295,7 +295,11 @@ namespace RaidExtractor.Core
 
         [Newtonsoft.Json.JsonProperty("arenaLeague", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ArenaLeague { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("greatHall", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Dictionary<Element, Dictionary<StatKindId, int>> GreatHall { get; set; }
     }
+    
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.24.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class Artifact

--- a/RaidExtractor.Core/AccountDumpClient.cs
+++ b/RaidExtractor.Core/AccountDumpClient.cs
@@ -5,6 +5,7 @@
 //----------------------
 
 using System.Collections.Generic;
+using RaidExtractor.Core.Native;
 
 #pragma warning disable 108 // Disable "CS0108 '{derivedDto}.ToJson()' hides inherited member '{dtoBase}.ToJson()'. Use the new keyword if hiding was intended."
 #pragma warning disable 114 // Disable "CS0114 '{derivedDto}.RaisePropertyChanged(String)' hides inherited member 'dtoBase.RaisePropertyChanged(String)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword."
@@ -292,7 +293,8 @@ namespace RaidExtractor.Core
         [Newtonsoft.Json.JsonProperty("heroes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Hero> Heroes { get; set; }
 
-
+        [Newtonsoft.Json.JsonProperty("arenaLeague", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ArenaLeague { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.24.0 (Newtonsoft.Json v11.0.0.0)")]

--- a/RaidExtractor.Core/Extractor.cs
+++ b/RaidExtractor.Core/Extractor.cs
@@ -69,12 +69,14 @@ namespace RaidExtractor.Core
                 var heroesWrapper = userWrapper;
                 NativeWrapper.ReadProcessMemory(handle, heroesWrapper + RaidStaticInformation.UserWrapperHeroes, ref heroesWrapper); // UserWrapper.Heroes
 
+#region Artifact Extraction
+
                 var artifactsPointer = heroesWrapper;
                 NativeWrapper.ReadProcessMemory(handle, artifactsPointer + RaidStaticInformation.HeroesWrapperArtifactData, ref artifactsPointer); // HeroesWrapperReadOnly.ArtifactData
                 NativeWrapper.ReadProcessMemory(handle, artifactsPointer + RaidStaticInformation.UserArtifactDataArtifacts, ref artifactsPointer); // UserArtifactData.Artifacts
 
                 var artifactCount = 0;
-                NativeWrapper.ReadProcessMemory(handle, artifactsPointer + 0x18, ref artifactCount); // List<Artifact>.Count
+                NativeWrapper.ReadProcessMemory(handle, artifactsPointer + RaidStaticInformation.ListCount, ref artifactCount); // List<Artifact>.Count
 
                 var pointers = new List<IntPtr>();
                 if (artifactCount > 0)
@@ -191,13 +193,17 @@ namespace RaidExtractor.Core
                     artifacts.Add(artifact);
                 }
 
+#endregion
+
+#region Hero Extraction
+
                 var heroesDataPointer = heroesWrapper;
                 NativeWrapper.ReadProcessMemory(handle, heroesDataPointer + RaidStaticInformation.HeroesWrapperHeroData, ref heroesDataPointer); // HeroesWrapperReadOnly.HeroData
                 NativeWrapper.ReadProcessMemory(handle, heroesDataPointer + RaidStaticInformation.UserHeroDataHeroById, ref heroesDataPointer); // UserHeroData.HeroById
 
                 var count = 0;
                 NativeWrapper.ReadProcessMemory(handle, heroesDataPointer + RaidStaticInformation.DictionaryCount, ref count); // Dictionary<int, Hero>.Count
-                NativeWrapper.ReadProcessMemory(handle, heroesDataPointer + 0x18, ref heroesDataPointer); // Dictionary<int, Hero>.entries
+                NativeWrapper.ReadProcessMemory(handle, heroesDataPointer + RaidStaticInformation.DictionaryEntries, ref heroesDataPointer); // Dictionary<int, Hero>.entries
 
                 var heroStruct = new HeroStruct();
                 var heroMasteriesStruct = new HeroMasteryDataStruct();
@@ -271,6 +277,10 @@ namespace RaidExtractor.Core
                     heroesById[heroStruct.Id] = hero;
                 }
 
+#endregion
+
+#region Hero Artifact Extraction
+
                 var artifactsByHeroIdPtr = heroesWrapper;
                 NativeWrapper.ReadProcessMemory(handle, artifactsByHeroIdPtr + RaidStaticInformation.HeroesWrapperArtifactData, ref artifactsByHeroIdPtr); // HeroesWrapperReadOnly.ArtifactData
                 NativeWrapper.ReadProcessMemory(handle, artifactsByHeroIdPtr + RaidStaticInformation.UserArtifactArtifactDataByHeroId, ref artifactsByHeroIdPtr); // UserArtifactData.ArtifactDataByHeroId
@@ -302,17 +312,71 @@ namespace RaidExtractor.Core
                     if (heroesById.TryGetValue(heroId, out var hero)) hero.Artifacts = arts;
                 }
 
+#endregion
+
+#region Arena League Extraction
+
                 var arenaPtr = userWrapper;
                 NativeWrapper.ReadProcessMemory(handle, userWrapper + RaidStaticInformation.UserWrapperArena, ref arenaPtr);
 
                 ArenaLeagueId arenaLeague = 0;
                 NativeWrapper.ReadProcessMemory(handle, arenaPtr + RaidStaticInformation.ArenaWrapperLeagueId, ref arenaLeague);
 
+#endregion
+
+#region Great Hall Extraction
+
+                var villageDataPointer = IntPtr.Zero;
+                NativeWrapper.ReadProcessMemory(handle, userWrapper + RaidStaticInformation.UserWrapperCapitol, ref villageDataPointer); // UserWrapper.Capitol
+                NativeWrapper.ReadProcessMemory(handle, villageDataPointer + RaidStaticInformation.CapitolWrapperVillageData, ref villageDataPointer); // Capitol.VillageData
+
+                var bonusLevelPointer = IntPtr.Zero;
+                NativeWrapper.ReadProcessMemory(handle, villageDataPointer + RaidStaticInformation.UserVillageDataCapitolBonusLevelByStatByElement, ref bonusLevelPointer); // UserVillageData.UserVillageDataCapitolBonusLevelByStatByElement
+
+                count = 0;
+                NativeWrapper.ReadProcessMemory(handle, bonusLevelPointer + RaidStaticInformation.DictionaryCount, ref count); // Dictionary<Element, Dictionary<StatKindId, int>>.Count
+                NativeWrapper.ReadProcessMemory(handle, bonusLevelPointer + RaidStaticInformation.DictionaryEntries, ref bonusLevelPointer); // Dictionary<Element, Dictionary<StatKindId, int>>.Entries
+
+                var greatHall = new Dictionary<Element, Dictionary<StatKindId, int>>();
+
+                for (var i = 0; i < count; i++)
+                {
+                    var elementPointer = bonusLevelPointer + 0x28 + 0x18 * i; // Dictionary<Element, Dictionary<StatKindId, int>>.Key;
+                    var statDictionaryPointer = bonusLevelPointer + 0x30 + 0x18 * i; // Dictionary<Element, Dictionary<StatKindId, int>>.Value
+
+                    Element currentElement = 0; // Initial value
+                    NativeWrapper.ReadProcessMemory(handle, elementPointer, ref currentElement);
+                    NativeWrapper.ReadProcessMemory(handle, statDictionaryPointer, ref statDictionaryPointer);
+
+                    var statsCount = 0;
+                    var statsPointer = IntPtr.Zero;
+                    var statsDictionary = new Dictionary<StatKindId, int>();
+
+                    NativeWrapper.ReadProcessMemory(handle, statDictionaryPointer + RaidStaticInformation.DictionaryCount, ref statsCount); // Dictionary<StatKindId, int>().Count
+                    NativeWrapper.ReadProcessMemory(handle, statDictionaryPointer + RaidStaticInformation.DictionaryEntries, ref statsPointer); // Dictionary<StatKindId, int>().Entries
+                    for (var j = 0; j < statsCount; j++)
+                    {
+                        var statKindPointer = statsPointer + 0x28 + 0x10 * j;
+                        var statValuePointer = statsPointer + 0x2C + 0x10 * j;
+
+                        StatKindId statKindId = 0;
+                        int statLevel = 0;
+                        NativeWrapper.ReadProcessMemory(handle, statKindPointer, ref statKindId);
+                        NativeWrapper.ReadProcessMemory(handle, statValuePointer, ref statLevel);
+
+                        statsDictionary.Add(statKindId, statLevel);
+                    }
+                    greatHall.Add(currentElement, statsDictionary);
+                }
+
+#endregion
+
                 return new AccountDump
                 {
                     Artifacts = artifacts,
                     Heroes = heroes,
                     ArenaLeague = arenaLeague.ToString(),
+                    GreatHall = greatHall
                 };
             }
             finally

--- a/RaidExtractor.Core/Extractor.cs
+++ b/RaidExtractor.Core/Extractor.cs
@@ -303,10 +303,10 @@ namespace RaidExtractor.Core
                 }
 
                 var arenaPtr = userWrapper;
-                NativeWrapper.ReadProcessMemory(handle, userWrapper + 0xB0, ref arenaPtr);
+                NativeWrapper.ReadProcessMemory(handle, userWrapper + RaidStaticInformation.UserWrapperArena, ref arenaPtr);
 
                 ArenaLeagueId arenaLeague = 0;
-                NativeWrapper.ReadProcessMemory(handle, arenaPtr + 0x40, ref arenaLeague);
+                NativeWrapper.ReadProcessMemory(handle, arenaPtr + RaidStaticInformation.ArenaWrapperLeagueId, ref arenaLeague);
 
                 return new AccountDump
                 {

--- a/RaidExtractor.Core/Extractor.cs
+++ b/RaidExtractor.Core/Extractor.cs
@@ -302,10 +302,17 @@ namespace RaidExtractor.Core
                     if (heroesById.TryGetValue(heroId, out var hero)) hero.Artifacts = arts;
                 }
 
+                var arenaPtr = userWrapper;
+                NativeWrapper.ReadProcessMemory(handle, userWrapper + 0xB0, ref arenaPtr);
+
+                ArenaLeagueId arenaLeague = 0;
+                NativeWrapper.ReadProcessMemory(handle, arenaPtr + 0x40, ref arenaLeague);
+
                 return new AccountDump
                 {
                     Artifacts = artifacts,
-                    Heroes = heroes
+                    Heroes = heroes,
+                    ArenaLeague = arenaLeague.ToString(),
                 };
             }
             finally

--- a/RaidExtractor.Core/Native/ArenaLeagueId.cs
+++ b/RaidExtractor.Core/Native/ArenaLeagueId.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RaidExtractor.Core.Native
+{
+    public enum ArenaLeagueId : int
+    {
+        None = 0,
+        BronzeI = 1,
+        BronzeII = 2,
+        BronzeIII = 3,
+        BronzeIV = 4,
+        SilverI = 11,
+        SilverII = 12,
+        SilverIII = 13,
+        SilverIV = 14,
+        GoldI = 21,
+        GoldII = 22,
+        GoldIII = 23,
+        GoldIV = 24,
+        Platinum = 30
+    }
+}

--- a/RaidExtractor.Core/Native/Element.cs
+++ b/RaidExtractor.Core/Native/Element.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RaidExtractor.Core.Native
+{
+    public enum Element : int
+    {
+        Magic = 1,
+        Force = 2,
+        Spirit = 3,
+        Void = 4
+    }
+}

--- a/RaidExtractor.Core/Native/RaidStaticInformation.cs
+++ b/RaidExtractor.Core/Native/RaidStaticInformation.cs
@@ -21,6 +21,8 @@ namespace RaidExtractor.Core.Native
         public static int HeroesWrapperArtifactData = 0x60; // HeroesWrapperReadOnly.ArtifactData
         public static int HeroesWrapperHeroData = 0x50; // HeroesWrapperReadOnly.HeroData
 
+        public static int ArenaWrapperLeagueId = 0x40; // ArenaWrapperReadOnly.LeagueId
+
         public static int DictionaryCount = 0x20; // Dictionary.Count
     }
 }

--- a/RaidExtractor.Core/Native/RaidStaticInformation.cs
+++ b/RaidExtractor.Core/Native/RaidStaticInformation.cs
@@ -6,6 +6,8 @@ namespace RaidExtractor.Core.Native
         public static int MemoryLocation = 56875040;
         public static int ExternalStorageAddress = 57009952;
 
+        public static int UserVillageDataCapitolBonusLevelByStatByElement = 0x30; // UserVillageData.UserVillageDataCapitolBonusLevelByStatByElement
+
         public static int UserHeroDataHeroById = 0x18; // UserHeroData.HeroById
 
         public static int UserArtifactDataArtifacts = 0x28; // UserArtifactData.Artifactsa
@@ -18,11 +20,15 @@ namespace RaidExtractor.Core.Native
         public static int UserWrapperArena = 0xB0; // UserWrapper.Arena
         public static int UserWrapperCapitol = 0xC8; // UserWrapper.Capitol
 
+        public static int CapitolWrapperVillageData = 0x18; // CapitolWrapperReadOnly.VillageData
+
         public static int HeroesWrapperArtifactData = 0x60; // HeroesWrapperReadOnly.ArtifactData
         public static int HeroesWrapperHeroData = 0x50; // HeroesWrapperReadOnly.HeroData
 
         public static int ArenaWrapperLeagueId = 0x40; // ArenaWrapperReadOnly.LeagueId
 
+        public static int DictionaryEntries = 0x18; // Dictionary.Entries
         public static int DictionaryCount = 0x20; // Dictionary.Count
+        public static int ListCount = 0x18; // List.Count
     }
 }

--- a/RaidExtractor/MainForm.cs
+++ b/RaidExtractor/MainForm.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using Newtonsoft.Json;
 using RaidExtractor.Core;
 using System.IO.Compression;
+using Newtonsoft.Json.Serialization;
 
 namespace RaidExtractor
 {
@@ -25,7 +26,7 @@ namespace RaidExtractor
             if (result == null) return;
             if (SaveJSONDialog.ShowDialog() != DialogResult.OK) return;
 
-            File.WriteAllText(SaveJSONDialog.FileName, JsonConvert.SerializeObject(result, Formatting.Indented));
+            File.WriteAllText(SaveJSONDialog.FileName, JsonConvert.SerializeObject(result, Program.SerializerSettings));
 
             if (SaveZipFile.Checked)
             {
@@ -41,7 +42,7 @@ namespace RaidExtractor
                         {
                             using (var streamWriter = new StreamWriter(entryStream))
                             {
-                                streamWriter.Write(JsonConvert.SerializeObject(result, Formatting.Indented));
+                                streamWriter.Write(JsonConvert.SerializeObject(result, Formatting.Indented, Program.SerializerSettings));
                             }
                         }
                     }

--- a/RaidExtractor/Program.cs
+++ b/RaidExtractor/Program.cs
@@ -79,16 +79,6 @@ namespace RaidExtractor
                         }
 
                         var outFile = o.OutputFile;
-
-                        var resolver = new DefaultContractResolver
-                        {
-                            NamingStrategy = new CamelCaseNamingStrategy
-                            {
-                                ProcessDictionaryKeys = true,
-                                OverrideSpecifiedNames = false
-                            }
-                        };
-
                         var json = JsonConvert.SerializeObject(dump, Formatting.Indented, SerializerSettings);
                         if (o.DumpType.ToLower() == "zip")
                         {

--- a/RaidExtractor/Program.cs
+++ b/RaidExtractor/Program.cs
@@ -6,11 +6,25 @@ using System.IO.Compression;
 using CommandLine;
 using RaidExtractor.Core;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace RaidExtractor
 {
     class Program
     {
+        public static JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    ProcessDictionaryKeys = true,
+                    OverrideSpecifiedNames = false
+                },
+            },
+        };
+
         public class Options
         {
             [Option('g', "nogui", Required = false, Default = false,
@@ -66,7 +80,16 @@ namespace RaidExtractor
 
                         var outFile = o.OutputFile;
 
-                        var json = JsonConvert.SerializeObject(dump, Formatting.Indented);
+                        var resolver = new DefaultContractResolver
+                        {
+                            NamingStrategy = new CamelCaseNamingStrategy
+                            {
+                                ProcessDictionaryKeys = true,
+                                OverrideSpecifiedNames = false
+                            }
+                        };
+
+                        var json = JsonConvert.SerializeObject(dump, Formatting.Indented, SerializerSettings);
                         if (o.DumpType.ToLower() == "zip")
                         {
                             if (!outFile.ToLower().Contains("zip")) outFile += ".zip";


### PR DESCRIPTION
These changes add support for arena league and great hall extraction.

Example output:
```
  "arenaLeague": "BronzeI",
  "greatHall": {
    "Force": {
      "Attack": 1,
      "CriticalDamage": 1,
      "Accuracy": 1,
      "Defense": 1
    },
    "Magic": {
      "Attack": 1,
      "CriticalDamage": 1,
      "Health": 1,
      "Defense": 1,
      "Accuracy": 1,
      "Resistance": 1
    },
    "Spirit": {
      "Attack": 1,
      "Accuracy": 1,
      "Defense": 1
    },
    "Void": {
      "Defense": 2,
      "Health": 1,
      "CriticalDamage": 1,
      "Attack": 1,
      "Accuracy": 1
    }
  }
```

The value of each stat represents the current level, not the underlying value. E.g.,  Void->Defense: 2 means level 2 and thus gives a 3% defense bonus.

One thing to note is that stats the user has not put any points into are missing from the stat object. Spirit, for example, is missing the CriticalDamange stat among others. Question here is whether we should always include all stats and simply default to 0 or only add the stats that were returned by the game (which is what you currently see above).

Another thing still remaining is the proper use of camelCase for the keys. I don't know if it's alright to manually add the schema definition to the AccountDump class since it was usually generated from the Swagger definition file. Seeing that the website part of this repo is no longer supported I am unsure how to proceed from here.

Also, I took the liberty to adapt the README to reflect recent commits and added items to the TODO for future versions. 