### PR TITLE
Support hero compositions extraction (aka battle presets)

### DIFF
--- a/Python Utilities/address_extractor.py
+++ b/Python Utilities/address_extractor.py
@@ -30,6 +30,7 @@ findclasslist = {
     }],
     'public class UserHeroData ': [{
         'public Dictionary<int, Hero> HeroById;': '        public static int UserHeroDataHeroById = {}; // UserHeroData.HeroById\n',
+        'public Dictionary<int, int[]> BattlePresets;': '        public static int UserHeroDataBattlePresets = {}; // UserHeroData.BattlePresets\n',
     }],
     'public class UserVillageData ': [{
         'public Dictionary<Element, Dictionary<StatKindId, int>> CapitolBonusLevelByStatByElement;': '        public static int UserVillageDataCapitolBonusLevelByStatByElement = {}; // UserVillageData.UserVillageDataCapitolBonusLevelByStatByElement\n',

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This application has 2 Modes:
 * .NET Framework 4.8
 
 ## Future versions
-* Extract last known hero compositions
 * Account stats
 
 ## Projects Using Extracted Data!

--- a/RaidExtractor.Core/AccountDumpClient.cs
+++ b/RaidExtractor.Core/AccountDumpClient.cs
@@ -301,6 +301,9 @@ namespace RaidExtractor.Core
 
         [Newtonsoft.Json.JsonProperty("shards", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Dictionary<string, ShardInfo> Shards { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("stagePresets", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Dictionary<int, int[]> StagePresets { get; set; }
     }
     
 

--- a/RaidExtractor.Core/Native/RaidStaticInformation.cs
+++ b/RaidExtractor.Core/Native/RaidStaticInformation.cs
@@ -12,6 +12,7 @@ namespace RaidExtractor.Core.Native
         public static int ShardSummonData = 0x18; // ShardWrapperReadOnly.UserShardData.SummonResults
 
         public static int UserHeroDataHeroById = 0x18; // UserHeroData.HeroById
+        public static int UserHeroDataBattlePresets = 0x28; // UserHeroData.BattlePresets
 
         public static int UserArtifactDataArtifacts = 0x28; // UserArtifactData.Artifactsa
         public static int UserArtifactArtifactDataByHeroId = 0x30; // UserArtifactData.ArtifactDataByHeroId


### PR DESCRIPTION
This PR introduces extraction for battle presets.

Sample output (formatted):
```
{
  "stagePresets": {
    "1012": [2174],
    "1013": [5767, 6026, 5002],
    "2035": [5906, 4176, 3833, 5002, 3073],
    "5035": [4176, 5002, 1314, 2174, 609],
    "3014": [6026, 3833, 5002, 3073],
    "1024": [4527, 3833, 1314, 5002],
    "1034": [4527, 1314, 5002, 4893],
    "1044": [4527, 4061, 3833, 5002],
    "2055": [5906, 1314, 3073, 3833, 5002],
    "2015": [5906, 3073, 1314, 5002, 3833],
    "2045": [5906, 3833, 3073, 5002, 6026],
    "2025": [5906, 4527, 1314, 3073, 3850],
    "4015": [3073, 5002, 3833, 6026, 3621],
    "1054": [4527, 3833, 5002, 4061],
    "2095": [5906, 6026, 1314, 3850, 4527],
    "2105": [4527, 1314, 4061, 5002, 5962],
    "2075": [5906, 5002, 6026, 3073, 5962],
    "1064": [1314, 3833, 6026, 5002],
    "2065": [5906, 5002, 3833, 5962, 6026],
    "1074": [1314, 4061],
    "1084": [6009, 1314, 3833, 3073],
    "1094": [1314, 6038, 5933, 6026],
    "2085": [5906, 3073, 5002, 3833, 3850],
    "1104": [1314, 4212, 5833, 4129],
    "1114": [1314, 3638, 3644, 3643],
    "5065": [334, 1835, 5822, 2539, 6026],
    "5055": [4527, 730, 4126, 3427, 3939],
    "1124": [1314, 4126, 5947, 6026],
    "1014": [2174, 4527, 1314, 5002],
    "5135": [6052, 3833, 2005, 1665, 2380],
    "6014": [6026, 4527, 3073, 5002, 4061, 3833, 5962, 1314, 3619, 3621, 5835, 3850]
  }
}

```

# How to use this data in 3rd-party applications
Presets are saved on a per-region, per-slots basis. To access a preset you need to have 2 types of information: 1) the RegionTypeId a given stage is in and 2) the amount of hero slots a stage can hold. Each key is composed of `{RegionTypeId}{Stage.UserHeroesCount}`. The value of each entry is a list of hero ids.

RegionTypeIds are static and currently defined in the game as:
```
public enum RegionTypeId
{
  Tower = -1,
  Region1 = 101,
  Region2 = 102,
  Region3 = 103,
  Region4 = 104,
  Region5 = 105,
  Region6 = 106,
  Region7 = 107,
  Region8 = 108,
  Region9 = 109,
  Region10 = 110,
  Region11 = 111,
  Region12 = 112,
  VoidKeep = 201,
  SpiritKeep = 202,
  MagicKeep = 203,
  ForceKeep = 204,
  ArcaneKeep = 205,
  DragonsLair = 206,
  IceGolemCave = 207,
  FireGolemCave = 208,
  SpiderCave = 209,
  MinotaurCave = 210,
  Arena = 301,
  AllianceBoss = 401,
  Fraction_BannerLords = 501,
  Fraction_HighElves = 502,
  Fraction_SacredOrder = 503,
  Fraction_OgrynTribes = 505,
  Fraction_LizardMen = 506,
  Fraction_Skinwalkers = 507,
  Fraction_Orcs = 508,
  Fraction_Demonspawn = 509,
  Fraction_UndeadHordes = 510,
  Fraction_DarkElves = 511,
  Fraction_KnightsRevenant = 512,
  Fraction_Barbarians = 513,
  Fraction_Dwarves = 516,
  Arena3x3 = 601,
  DoomTower1 = 701,
  DoomTower2 = 702,
  DoomTower3 = 703
}
```

## Example
Getting the presets for

Campaign "Brimstone Path", Stage 3:
- Brimstone Path has `RegionTypeId` of `112`.
- Stage 3 of Brimstone Path can hold `4` heroes.
- Thus, our key will be: `1124`. 

 Clan Boss
- Clan Boss (internally referenced as AllianceBoss) has  `RegionTypeId` of `401`. 
- An attack team in a clan boss can hold `5` heroes.
- Thus, our key will be `4015`.

## Special case Kaerok Castle (Region 1).
The first region in the campaign has a slightly different setup than the rest and therefore you will find additional `101x` entries:

- Stage 1-4 on Normal only allow for 2 hero slots. (`1012`)
- Stage 4-7 on Normal only allow for 3 hero slots. (`1013`)
- Stage 1-7 on Hard and up allow for 4 hero slots. (`1014`)

## Special case Tag Team Arena
Tag Team Arena (internally refered to as Arena3x3) uses a slot count of `4` , despite being able to select 12 heroes. Therefore the key will be `6014`. The value will hold up to 12 heroes though.

## Normalizing the data
If your application does not care for the special case of Kaerok Castle you could simply remove `1012`, and `1013` from the object and map the key to Enums directly by dividing the key by 10. `1014` would become `101` which maps to `Region1`, `2035` would become `203` and maps to `MagicKeep`, and so on.