### PR TITLE
Update enums according to Raid v238

### DIFF
--- a/RaidExtractor.Core/Native/HeroFraction.cs
+++ b/RaidExtractor.Core/Native/HeroFraction.cs
@@ -17,7 +17,7 @@
         KnightsRevenant = 12,
         Barbarians = 13,
         NyresanElves = 14,
-        AssassinsGuild = 15,
+        Samurai = 15,
         Dwarves = 16,
     }
 }


### PR DESCRIPTION
This PR updates enums to reflect changes made in Raid v238 (or prior).

I re-checked all enums in RaidExtractor.Core/Native and compared them to the the current Raid build. Only ```HeroFraction.cs``` seems to have changed.

Should fix #62.