### PR TITLE
Add skills to heroes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RaidExtractor
-A tool made to extract information from the windows version of "Raid: Shadow Legends". Currently it supports v0.237 (as seen in Plarium Play launcher) and currently only extracts artifacts and current champions.
+A tool made to extract information from the windows version of "Raid: Shadow Legends". Currently it supports v0.239 (as seen in Plarium Play launcher) and currently only extracts artifacts and current champions.
 
 This application has 2 Modes:
 * A Windows GUI application. The functionality is slim, but it works!

--- a/RaidExtractor.Core/AccountDumpClient.cs
+++ b/RaidExtractor.Core/AccountDumpClient.cs
@@ -456,6 +456,22 @@ namespace RaidExtractor.Core
 
         [Newtonsoft.Json.JsonProperty("masteries", Required = Newtonsoft.Json.Required.Always)]
         public List<int> Masteries { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("skills", Required = Newtonsoft.Json.Required.Always)]
+        public List<Skill> Skills { get; set; }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.24.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class Skill
+    {
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Always)]
+        public int Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("typeId", Required = Newtonsoft.Json.Required.Always)]
+        public int TypeId { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("level", Required = Newtonsoft.Json.Required.Always)]
+        public int Level { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.24.0 (Newtonsoft.Json v11.0.0.0)")]

--- a/RaidExtractor.Core/Native/SkillStruct.cs
+++ b/RaidExtractor.Core/Native/SkillStruct.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace RaidExtractor.Core.Native
+{
+    [StructLayout(LayoutKind.Explicit)]
+    public struct SkillStruct
+    {
+        [FieldOffset(0x18)]
+        public int Id; 
+        [FieldOffset(0x1C)]
+        public int TypeId; 
+        [FieldOffset(0x20)]
+        public int Level;
+    }
+}


### PR DESCRIPTION
This PR introduces skill data for each hero:

```
...
  "skills": [
    {
      "id": 0,
      "typeId": 47801,
      "level": 4
    },
    {
      "id": 1,
      "typeId": 47802,
      "level": 7
    },
    {
      "id": 2,
      "typeId": 47803,
      "level": 4
    },
    {
      "id": 3,
      "typeId": 47804,
      "level": 1
    }
  ]
...
```
In addition this PR squashes more magic numbers and updates the README to reflect the new Raid version.

Should help with #52.