### PR TITLE
Automatic generation of datavalues.json resource file.

### DIFF
--- a/RaidExtractor.Core/RaidExtractor.Core.csproj
+++ b/RaidExtractor.Core/RaidExtractor.Core.csproj
@@ -47,4 +47,7 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="if EXIST %25APPDATA%25\\RaidExtractor\\datavalues.json copy /Y %25APPDATA%25\\RaidExtractor\\datavalues.json $(ProjectDir)datavalues.json" />
+  </Target>
 </Project>

--- a/RaidExtractor.Core/datavalues.json
+++ b/RaidExtractor.Core/datavalues.json
@@ -1,13 +1,13 @@
 {
-  "version": "\\240\\",
+  "version": "\\241\\",
   "values": [
     {
       "name": "MemoryLocation",
-      "value": 57020984
+      "value": 57761344
     },
     {
       "name": "ExternalStorageAddress",
-      "value": 57155120
+      "value": 57856976
     },
     {
       "name": "AppModelUserWrapper",
@@ -31,11 +31,11 @@
     },
     {
       "name": "HeroesWrapperArtifactData",
-      "value": 96
+      "value": 104
     },
     {
       "name": "HeroesWrapperHeroData",
-      "value": 80
+      "value": 88
     },
     {
       "name": "ArenaWrapperLeagueId",

--- a/RaidExtractor/RaidExtractor.csproj
+++ b/RaidExtractor/RaidExtractor.csproj
@@ -51,6 +51,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>AppIcon.ico</ApplicationIcon>
@@ -76,7 +77,9 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>AppSettings.settings</DependentUpon>
     </Compile>
-    <Compile Include="MainForm.cs" />
+    <Compile Include="MainForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
Datavalues.json is now saved to AppData/Roaming/RaidExtractor. The dev version will look here after trying the inbuilt resource, and will use it if the version is correct.

The project also has a new pre build step, which copies that file, if it exists, over the data file used for resource generation, so running the dev version, followed by building the non dev version is sufficient for updating the data.